### PR TITLE
Implement advanced quiz system

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This project recreates the iconic HyperCard experience from 1987, complete with 
 
 ### Educational Content
 - **Structured Learning**: Progressive difficulty from basic concepts to practical applications
-- **Interactive Quiz**: Multiple-choice questions with immediate feedback
+- **Interactive Quiz**: Advanced system with multiple question types, scoring and certificates
 - **Visual Elements**: Custom sprites and icons enhancing the learning experience
 - **Progress Indicators**: Clear tracking of completed sections and visited cards
 
@@ -237,8 +237,7 @@ yarn lint         # Run ESLint
 
 ## 🔮 Next Steps and Future Enhancements
 
-### Phase 2: Enhanced Interactivity
-- **Advanced Quiz System**: Multiple question types, scoring, certificates
+- **Advanced Quiz System** ✅ Implemented with multiple question types, scoring, and certificate display. See [docs/quiz-system.md](docs/quiz-system.md)
 - **Interactive Animations**: Card transitions, hover effects, loading states
 - **Sound Effects**: Authentic Mac system sounds and feedback
 - **Gesture Support**: Touch gestures for mobile navigation

--- a/app/__tests__/quiz-utils.test.ts
+++ b/app/__tests__/quiz-utils.test.ts
@@ -1,0 +1,18 @@
+import { calculateScore, QuizQuestionDef } from '../lib/utils';
+
+describe('calculateScore', () => {
+  const questions: QuizQuestionDef[] = [
+    { id: 1, type: 'multiple-choice', answer: 'A', points: 5 },
+    { id: 2, type: 'true-false', answer: true, points: 5 },
+  ];
+
+  it('calculates total points for correct answers', () => {
+    const answers = { 1: 'A', 2: 'true' };
+    expect(calculateScore(questions, answers)).toBe(10);
+  });
+
+  it('gives zero for incorrect answers', () => {
+    const answers = { 1: 'B', 2: 'false' };
+    expect(calculateScore(questions, answers)).toBe(0);
+  });
+});

--- a/app/app/api/quiz/route.ts
+++ b/app/app/api/quiz/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { sessionId, result, score } = body;
+  if (!sessionId) {
+    return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+  }
+  const saved = await prisma.quizResult.create({
+    data: { sessionId, result, score },
+  });
+  return NextResponse.json(saved);
+}
+
+export async function GET(request: NextRequest) {
+  const sessionId = request.nextUrl.searchParams.get('sessionId') ?? '';
+  if (!sessionId) {
+    return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+  }
+  const result = await prisma.quizResult.findMany({
+    where: { sessionId },
+  });
+  return NextResponse.json(result);
+}

--- a/app/components/card-stack.tsx
+++ b/app/components/card-stack.tsx
@@ -9,6 +9,7 @@ const Card1Welcome = dynamic(() => import('./cards/card-1-welcome').then(m => m.
 const Card2WhatIsAI = dynamic(() => import('./cards/card-2-what-is-ai').then(m => m.Card2WhatIsAI));
 const Card3AITools = dynamic(() => import('./cards/card-3-ai-tools').then(m => m.Card3AITools));
 const Card4Quiz = dynamic(() => import('./cards/card-4-quiz').then(m => m.Card4Quiz));
+const Card5AdvancedQuiz = dynamic(() => import('./cards/card-5-advanced-quiz').then(m => m.default));
 
 export function CardStack() {
   const { state } = useHyperCard();
@@ -17,7 +18,8 @@ export function CardStack() {
     <Card1Welcome key="card-1" />,
     <Card2WhatIsAI key="card-2" />,
     <Card3AITools key="card-3" />,
-    <Card4Quiz key="card-4" />
+    <Card4Quiz key="card-4" />,
+    <Card5AdvancedQuiz key="card-5" />
   ];
 
   return (

--- a/app/components/cards/card-5-advanced-quiz.tsx
+++ b/app/components/cards/card-5-advanced-quiz.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+import { AdvancedQuiz } from '../quiz/advanced-quiz';
+
+export default function Card5AdvancedQuiz() {
+  return (
+    <div className="w-full h-full bg-white p-3 flex flex-col">
+      <div className="text-center mb-2">
+        <h1 className="text-lg font-bold mb-1">Advanced Quiz</h1>
+        <div className="w-full h-px bg-black mb-2"></div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <AdvancedQuiz />
+      </div>
+    </div>
+  );
+}

--- a/app/components/quiz/advanced-quiz.tsx
+++ b/app/components/quiz/advanced-quiz.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React, { useState } from 'react';
+import questionsData from '../../data/advanced-quiz.json';
+import { QuizQuestion, Question } from './question';
+import { HCButton } from '../hc-button';
+import { HCField } from '../hc-field';
+import { useHyperCard } from '@/lib/hypercard-context';
+
+export function AdvancedQuiz() {
+  const { dispatch } = useHyperCard();
+  const questions = questionsData as Question[];
+  const [current, setCurrent] = useState(0);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [score, setScore] = useState<number | null>(null);
+
+  const question = questions[current];
+
+  const handleChange = (val: string) => {
+    setAnswers((a) => ({ ...a, [question.id]: val }));
+  };
+
+  const next = () => {
+    if (current < questions.length - 1) {
+      setCurrent(current + 1);
+    } else {
+      finish();
+    }
+  };
+
+  const finish = () => {
+    let total = 0;
+    questions.forEach((q) => {
+      const user = answers[q.id];
+      if (user === undefined) return;
+      const correct = typeof q.answer === 'boolean' ? String(q.answer) : String(q.answer).toLowerCase();
+      const provided = typeof q.answer === 'boolean' ? user : user.toLowerCase();
+      if (provided === correct) total += q.points;
+    });
+    setScore(total);
+    dispatch({ type: 'SAVE_QUIZ_RESULT', payload: { answers, score: total } });
+    const sessionId =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('hypercard-session-id') || ''
+        : '';
+    fetch('/api/quiz', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, result: answers, score: total }),
+    }).catch((e) => console.warn('Failed to save quiz', e));
+  };
+
+  if (score !== null) {
+    return (
+      <div className="space-y-2">
+        <HCField readonly className="p-2 bg-blue-50 text-xs">
+          Your score: {score}
+        </HCField>
+        {score >= 20 && (
+          <div id="certificate" className="p-2 border text-xs">
+            <strong>Certificate of Completion</strong>
+            <div>You passed the AI Primer Quiz!</div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <QuizQuestion
+        data={question}
+        value={answers[question.id] || ''}
+        onChange={handleChange}
+      />
+      <div className="text-center">
+        <HCButton onClick={next} className="px-4 py-1 text-xs">
+          {current < questions.length - 1 ? 'Next' : 'Finish'}
+        </HCButton>
+      </div>
+    </div>
+  );
+}

--- a/app/components/quiz/question.tsx
+++ b/app/components/quiz/question.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React from 'react';
+import { HCField } from '../hc-field';
+
+export type Question = {
+  id: number;
+  type: 'multiple-choice' | 'true-false' | 'text';
+  question: string;
+  options?: string[];
+  answer: string | boolean;
+  points: number;
+};
+
+interface Props {
+  data: Question;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function QuizQuestion({ data, value, onChange }: Props) {
+  if (data.type === 'multiple-choice') {
+    return (
+      <div className="space-y-1">
+        <HCField readonly className="p-2 bg-gray-100 text-xs">
+          {data.question}
+        </HCField>
+        {data.options?.map((opt) => (
+          <label key={opt} className="flex items-center space-x-1 text-xs">
+            <input
+              type="radio"
+              name={`q-${data.id}`}
+              value={opt}
+              checked={value === opt}
+              onChange={() => onChange(opt)}
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    );
+  }
+
+  if (data.type === 'true-false') {
+    return (
+      <div className="space-y-1">
+        <HCField readonly className="p-2 bg-gray-100 text-xs">
+          {data.question}
+        </HCField>
+        {['True', 'False'].map((opt) => (
+          <label key={opt} className="flex items-center space-x-1 text-xs">
+            <input
+              type="radio"
+              name={`q-${data.id}`}
+              value={opt}
+              checked={value === opt}
+              onChange={() => onChange(opt)}
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    );
+  }
+
+  // text question
+  return (
+    <div className="space-y-1">
+      <HCField readonly className="p-2 bg-gray-100 text-xs">
+        {data.question}
+      </HCField>
+      <HCField
+        value={value}
+        onChange={onChange}
+        placeholder="Your answer..."
+        multiline
+        className="min-h-[60px] text-xs"
+      />
+    </div>
+  );
+}

--- a/app/data/advanced-quiz.json
+++ b/app/data/advanced-quiz.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": 1,
+    "type": "multiple-choice",
+    "question": "Which of these is a type of machine learning?",
+    "options": ["Supervised learning", "Random searching", "Alchemy", "Supercharging"],
+    "answer": "Supervised learning",
+    "points": 10
+  },
+  {
+    "id": 2,
+    "type": "true-false",
+    "question": "Neural networks are inspired by the human brain.",
+    "answer": true,
+    "points": 5
+  },
+  {
+    "id": 3,
+    "type": "text",
+    "question": "Name one commonly used library for building neural networks in JavaScript.",
+    "answer": "TensorFlow.js",
+    "points": 15
+  }
+]

--- a/app/lib/hypercard-context.tsx
+++ b/app/lib/hypercard-context.tsx
@@ -6,11 +6,12 @@ import { HyperCardState, NavigationAction } from './types';
 
 const initialState: HyperCardState = {
   currentCard: 1,
-  totalCards: 4,
+  totalCards: 5,
   userProgress: {
     visitedCards: [1],
     quizAnswers: {},
-    completedSections: []
+    completedSections: [],
+    quizScore: 0
   }
 };
 
@@ -67,6 +68,15 @@ function hypercardReducer(state: HyperCardState, action: NavigationAction): Hype
             ...state.userProgress.quizAnswers,
             [action.payload.question]: action.payload.answer
           }
+        }
+      };
+
+    case 'SAVE_QUIZ_RESULT':
+      return {
+        ...state,
+        userProgress: {
+          ...state.userProgress,
+          quizScore: action.payload.score
         }
       };
     

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -13,10 +13,17 @@ export interface HyperCardState {
     visitedCards: number[];
     quizAnswers: Record<string, string>;
     completedSections: string[];
+    quizScore?: number;
   };
 }
 
 export interface NavigationAction {
-  type: 'NEXT_CARD' | 'PREV_CARD' | 'GO_TO_CARD' | 'UPDATE_PROGRESS' | 'SAVE_QUIZ_ANSWER';
+  type:
+    | 'NEXT_CARD'
+    | 'PREV_CARD'
+    | 'GO_TO_CARD'
+    | 'UPDATE_PROGRESS'
+    | 'SAVE_QUIZ_ANSWER'
+    | 'SAVE_QUIZ_RESULT';
   payload?: any;
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
- 
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
@@ -11,4 +11,26 @@ export function formatDuration(seconds: number): string {
   const remainingSeconds = seconds % 60
 
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`
+}
+
+export interface QuizQuestionDef {
+  id: number
+  type: 'multiple-choice' | 'true-false' | 'text'
+  answer: string | boolean
+  points: number
+}
+
+export function calculateScore(
+  questions: QuizQuestionDef[],
+  answers: Record<number, string>
+): number {
+  let total = 0
+  for (const q of questions) {
+    const val = answers[q.id]
+    if (val === undefined) continue
+    const correct = typeof q.answer === 'boolean' ? String(q.answer) : String(q.answer).toLowerCase()
+    const provided = typeof q.answer === 'boolean' ? val : val.toLowerCase()
+    if (provided === correct) total += q.points
+  }
+  return total
 }

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -16,3 +16,14 @@ model Progress {
     createdAt  DateTime @default(now())
     updatedAt  DateTime @updatedAt
 }
+
+model QuizResult {
+    id        Int      @id @default(autoincrement())
+    sessionId String
+    result    Json
+    score     Int
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    @@index([sessionId])
+}

--- a/docs/quiz-system.md
+++ b/docs/quiz-system.md
@@ -1,0 +1,26 @@
+# Advanced Quiz System Architecture
+
+This document outlines the high level structure of the Phase II quiz engine.
+
+## Components
+
+- **Question Data** – defined in `app/data/advanced-quiz.json`. Each entry
+  specifies a type (`multiple-choice`, `true-false`, or `text`), available
+  options, the correct answer and the points awarded.
+- **React Components** – the quiz UI is built from `QuizQuestion` and
+  `AdvancedQuiz` in `app/components/quiz/`. `AdvancedQuiz` manages navigation
+  through questions, scoring and certificate display.
+- **State Management** – results are stored in the HyperCard context via the
+  `SAVE_QUIZ_RESULT` action. Progress is still persisted to the server through
+  `/api/progress`.
+- **Server Persistence** – quiz results are saved with the new `/api/quiz`
+  endpoint. Data is stored in the `QuizResult` table defined in the Prisma
+  schema.
+- **Certificate** – once the final score is calculated, a simple certificate is
+  displayed if the user scores at least 20 points. This can later be enhanced to
+  export a PDF or image.
+
+## Extending
+
+Other agents can add more question types or hook additional features (like PDF
+export) by building on the components and API described here.


### PR DESCRIPTION
## Summary
- add advanced quiz data and React components for new quiz system
- extend card stack with a new advanced quiz card
- persist quiz results using a new Prisma model and API route
- implement scoring util and tests
- document quiz architecture
- update README with completed Phase II feature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caabc6ff0832ab8f1171488830db2