### PR TITLE
Update card limits to 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ This project recreates the iconic HyperCard experience from 1987, complete with 
 4. **Routing System**: Implemented SPA routing for direct card access via URLs
 
 ### Stage 2: Content and Educational Structure
-1. **Card Development**: Created 4-card educational deck covering AI fundamentals
+1. **Card Development**: Created 6-card educational deck covering AI fundamentals
    - Card 1: Welcome and introduction
    - Card 2: "What is AI?" - Core concepts and definitions
    - Card 3: "AI Tools" - Practical applications and examples
    - Card 4: Interactive quiz with progress tracking
+   - Card 5: Advanced quiz with scoring and certificate
+   - Card 6: Gesture and certificate instructions
 2. **Content Integration**: Added educational content with proper information hierarchy
 3. **Interactive Elements**: Implemented quiz functionality with answer persistence
 
@@ -113,7 +115,9 @@ This project recreates the iconic HyperCard experience from 1987, complete with 
     │   │   ├── card-1-welcome.tsx   # Welcome/intro card
     │   │   ├── card-2-what-is-ai.tsx # AI concepts explanation
     │   │   ├── card-3-ai-tools.tsx  # Practical AI applications
-    │   │   └── card-4-quiz.tsx      # Interactive quiz
+    │   │   ├── card-4-quiz.tsx      # Interactive quiz
+    │   │   ├── card-5-advanced-quiz.tsx # Advanced quiz with certificate
+    │   │   └── card-6-gestures.tsx  # Gesture instructions
     │   ├── ui/                      # Radix UI components
     │   ├── card-stack.tsx           # Main card container
     │   ├── card-viewport.tsx        # Card display viewport

--- a/app/app/card/[id]/page.tsx
+++ b/app/app/card/[id]/page.tsx
@@ -14,7 +14,7 @@ function CardPageContent() {
 
   useEffect(() => {
     const cardId = parseInt(params.id as string);
-    if (isNaN(cardId) || cardId < 1 || cardId > 4) {
+    if (isNaN(cardId) || cardId < 1 || cardId > state.totalCards) {
       router.push('/');
       return;
     }

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,0 +1,1 @@
+export const TOTAL_CARDS = 6;

--- a/app/lib/hypercard-context.tsx
+++ b/app/lib/hypercard-context.tsx
@@ -3,10 +3,11 @@
 
 import React, { createContext, useContext, useReducer, useEffect, useState } from 'react';
 import { HyperCardState, NavigationAction } from './types';
+import { TOTAL_CARDS } from './constants';
 
 const initialState: HyperCardState = {
   currentCard: 1,
-  totalCards: 6,
+  totalCards: TOTAL_CARDS,
   userProgress: {
     visitedCards: [1],
     quizAnswers: {},

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,6 +1,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { TOTAL_CARDS } from './lib/constants';
 
 export function middleware(request: NextRequest) {
   // Handle card routing
@@ -9,7 +10,7 @@ export function middleware(request: NextRequest) {
     const id = parseInt(cardId);
     
     // Redirect invalid card IDs to home
-    if (isNaN(id) || id < 1 || id > 4) {
+    if (isNaN(id) || id < 1 || id > TOTAL_CARDS) {
       return NextResponse.redirect(new URL('/', request.url));
     }
   }


### PR DESCRIPTION
## Summary
- centralize total card count in `constants.ts`
- use the new constant when validating card routes
- document all six cards in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb3b750a0832a949f9a28c9d7f912