### PR TITLE
Rename HCButton style prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This project recreates the iconic HyperCard experience from 1987, complete with 
 3. **Progress Persistence**: Implemented localStorage for user progress tracking
 4. **Cross-browser Testing**: Ensured compatibility across modern browsers
 5. **Documentation**: Comprehensive README and code documentation
+6. **API Cleanup**: Renamed `HCButton` prop `style` to `variant` for clarity
 
 ## ✨ Current MVP Features
 

--- a/app/components/cards/card-1-welcome.tsx
+++ b/app/components/cards/card-1-welcome.tsx
@@ -36,7 +36,7 @@ export function Card1Welcome() {
           {cardContent.note}
         </HCField>
 
-        <HCButton onClick={handleStart} style="shadow" className="px-4 py-1 text-sm">
+        <HCButton onClick={handleStart} variant="shadow" className="px-4 py-1 text-sm">
           Start Learning
         </HCButton>
       </div>

--- a/app/components/cards/card-2-what-is-ai.tsx
+++ b/app/components/cards/card-2-what-is-ai.tsx
@@ -52,7 +52,7 @@ export function Card2WhatIsAI() {
 
       {/* Navigation */}
       <div className="text-center mt-2">
-        <HCButton onClick={handleContinue} style="shadow" className="px-4 py-1 text-sm">
+        <HCButton onClick={handleContinue} variant="shadow" className="px-4 py-1 text-sm">
           Continue →
         </HCButton>
       </div>

--- a/app/components/cards/card-3-ai-tools.tsx
+++ b/app/components/cards/card-3-ai-tools.tsx
@@ -41,10 +41,10 @@ export function Card3AITools() {
           <div key={tool.name} className="space-y-1">
             <div className="flex items-center space-x-2">
               <HCSprite type={tool.icon} size="small" />
-              <HCButton 
+              <HCButton
                 onClick={() => handleToolClick(tool.name)}
                 className="flex-1 text-left text-xs px-2 py-1"
-                style={selectedTool === tool.name ? "shadow" : "default"}
+                variant={selectedTool === tool.name ? "shadow" : "default"}
               >
                 {index + 1}. {tool.name}
               </HCButton>
@@ -61,7 +61,7 @@ export function Card3AITools() {
 
       {/* Navigation */}
       <div className="text-center mt-2">
-        <HCButton onClick={handleContinue} style="shadow" className="px-4 py-1 text-sm">
+        <HCButton onClick={handleContinue} variant="shadow" className="px-4 py-1 text-sm">
           Take Quiz →
         </HCButton>
       </div>

--- a/app/components/cards/card-4-quiz.tsx
+++ b/app/components/cards/card-4-quiz.tsx
@@ -79,9 +79,9 @@ export function Card4Quiz() {
 
         {!showResult ? (
           <div className="text-center">
-            <HCButton 
-              onClick={handleCheck} 
-              style="shadow" 
+            <HCButton
+              onClick={handleCheck}
+              variant="shadow"
               className="px-4 py-1 text-sm"
               disabled={!answer.trim()}
             >
@@ -96,7 +96,7 @@ export function Card4Quiz() {
             </HCField>
 
             <div className="flex justify-center space-x-2">
-              <HCButton onClick={handleRestart} style="shadow" className="px-3 py-1 text-xs">
+              <HCButton onClick={handleRestart} variant="shadow" className="px-3 py-1 text-xs">
                 Start Over
               </HCButton>
               <HCButton 

--- a/app/components/cards/card-6-gestures.tsx
+++ b/app/components/cards/card-6-gestures.tsx
@@ -28,7 +28,7 @@ export function Card6Gestures() {
         </HCField>
       </div>
       <div className="text-center mt-2">
-        <HCButton onClick={handleNext} style="shadow" className="px-4 py-1 text-sm">
+        <HCButton onClick={handleNext} variant="shadow" className="px-4 py-1 text-sm">
           Continue →
         </HCButton>
       </div>

--- a/app/components/hc-button.tsx
+++ b/app/components/hc-button.tsx
@@ -9,7 +9,7 @@ import { useSound } from '../hooks/use-sound';
 interface HCButtonProps {
   children: React.ReactNode;
   onClick?: () => void;
-  style?: 'default' | 'round' | 'shadow';
+  variant?: 'default' | 'round' | 'shadow';
   disabled?: boolean;
   className?: string;
   sound?: boolean;
@@ -18,7 +18,7 @@ interface HCButtonProps {
 export function HCButton({
   children,
   onClick,
-  style = 'default',
+  variant = 'default',
   disabled = false,
   className = '',
   sound = true
@@ -27,7 +27,7 @@ export function HCButton({
 
   const playSound = useSound(sound && !disabled);
   
-  const styleClasses = {
+  const variantClasses = {
     default: 'rounded-none',
     round: 'rounded-lg',
     shadow: 'rounded-none shadow-lg'
@@ -42,7 +42,7 @@ export function HCButton({
   return (
     <motion.button
       whileHover={{ scale: disabled ? 1 : 1.05 }}
-      className={`${baseClasses} ${styleClasses[style]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+      className={`${baseClasses} ${variantClasses[variant]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
       onClick={handleClick}
       disabled={disabled}
       style={{

--- a/app/components/navigation-controls.tsx
+++ b/app/components/navigation-controls.tsx
@@ -38,7 +38,7 @@ export function NavigationControls() {
       <div className="flex justify-center gap-4 items-center">
         <HCButton
           onClick={() => dispatch({ type: 'GO_TO_CARD', payload: 1 })}
-          style="shadow"
+          variant="shadow"
           className="text-sm px-4 py-2"
         >
           🏠 Home


### PR DESCRIPTION
## Summary
- rename HCButton `style` prop to `variant`
- update component usages to use the new `variant` prop
- document the change in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb3e4f150832a80fed47011ade32b