### PR TITLE
Fix Prisma client path

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ cd hypercard-ai-primer/app
 # Install dependencies
 yarn install
 
+# Generate Prisma client
+npx prisma generate
+
 # Start development server
 yarn dev
 

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
     provider = "prisma-client-js"
     binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
-    output = "/home/ubuntu/hypercard-ai-primer/app/node_modules/.prisma/client"
+    output = "./node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- update prisma client generator to use a relative output path
- document generating the Prisma client in setup instructions

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684cb73630bc832ab47f83da29b4c631