### PR TITLE
Update TS target to ES2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ yarn install
 - **Node.js**: Version 18+ required
 - **Yarn**: Preferred package manager
 - **TypeScript**: Configured for strict mode
+- **TypeScript target**: `es2017`
 
 ## 🛠️ Development Setup and Running
 

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Summary
- bump TypeScript target to `es2017`
- document the new target version in the README

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684cb74b3d70832ab6f7cb1880cb59a1