### PR TITLE
Refactor navigation action types

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ yarn lint         # Run ESLint
 - **Introduce error boundaries** ✅ Application wrapped with a reusable error boundary component.
 - **Audit dependencies** ✅ Removed unused packages like charting and map libraries.
 - **Persist progress server-side** ✅ Progress now saved to a Prisma `Progress` table via an API route.
+- **Typed navigation actions** ✅ `NavigationAction` is now a discriminated union for clearer reducer logic.
 
 ---
 

--- a/app/lib/hypercard-context.tsx
+++ b/app/lib/hypercard-context.tsx
@@ -46,10 +46,10 @@ function hypercardReducer(state: HyperCardState, action: NavigationAction): Hype
         }
       };
     
-    case 'GO_TO_CARD':
+    case 'GO_TO_CARD': {
       const targetCard = Math.max(1, Math.min(action.payload, state.totalCards));
-      const targetVisitedCards = state.userProgress.visitedCards.includes(targetCard) 
-        ? state.userProgress.visitedCards 
+      const targetVisitedCards = state.userProgress.visitedCards.includes(targetCard)
+        ? state.userProgress.visitedCards
         : [...state.userProgress.visitedCards, targetCard];
       return {
         ...state,
@@ -59,32 +59,38 @@ function hypercardReducer(state: HyperCardState, action: NavigationAction): Hype
           visitedCards: targetVisitedCards
         }
       };
+    }
     
-    case 'SAVE_QUIZ_ANSWER':
+    case 'SAVE_QUIZ_ANSWER': {
+      const { question, answer } = action.payload;
       return {
         ...state,
         userProgress: {
           ...state.userProgress,
           quizAnswers: {
             ...state.userProgress.quizAnswers,
-            [action.payload.question]: action.payload.answer
+            [question]: answer
           }
         }
       };
+    }
 
-    case 'SAVE_QUIZ_RESULT':
+    case 'SAVE_QUIZ_RESULT': {
+      const { score } = action.payload;
       return {
         ...state,
         userProgress: {
           ...state.userProgress,
-          quizScore: action.payload.score
+          quizScore: score
         }
       };
+    }
     
-    case 'UPDATE_PROGRESS':
-      const updatedSections = state.userProgress.completedSections.includes(action.payload) 
-        ? state.userProgress.completedSections 
-        : [...state.userProgress.completedSections, action.payload];
+    case 'UPDATE_PROGRESS': {
+      const section = action.payload;
+      const updatedSections = state.userProgress.completedSections.includes(section)
+        ? state.userProgress.completedSections
+        : [...state.userProgress.completedSections, section];
       return {
         ...state,
         userProgress: {
@@ -92,6 +98,7 @@ function hypercardReducer(state: HyperCardState, action: NavigationAction): Hype
           completedSections: updatedSections
         }
       };
+    }
     
     default:
       return state;

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -17,13 +17,10 @@ export interface HyperCardState {
   };
 }
 
-export interface NavigationAction {
-  type:
-    | 'NEXT_CARD'
-    | 'PREV_CARD'
-    | 'GO_TO_CARD'
-    | 'UPDATE_PROGRESS'
-    | 'SAVE_QUIZ_ANSWER'
-    | 'SAVE_QUIZ_RESULT';
-  payload?: any;
-}
+export type NavigationAction =
+  | { type: 'NEXT_CARD' }
+  | { type: 'PREV_CARD' }
+  | { type: 'GO_TO_CARD'; payload: number }
+  | { type: 'UPDATE_PROGRESS'; payload: string }
+  | { type: 'SAVE_QUIZ_ANSWER'; payload: { question: number; answer: string } }
+  | { type: 'SAVE_QUIZ_RESULT'; payload: { score: number } };


### PR DESCRIPTION
## Summary
- use a discriminated union for `NavigationAction`
- update the hypercard reducer to use the new types
- document typed navigation actions in the README

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684cb75c1dd4832a978d13bc6cafa1fb