### PR TITLE
Persist audio context for button sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ yarn install
 - Yarn package manager
 - Modern web browser
 - Audio playback requires a user interaction to start due to browser autoplay policies
+- Some browsers restrict the number of active `AudioContext` instances, so each
+  component cleans up its audio context on unmount
 
 ### Installation and Development
 ```bash

--- a/app/__tests__/hc-button-sound.test.tsx
+++ b/app/__tests__/hc-button-sound.test.tsx
@@ -1,13 +1,16 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { HCButton } from '../components/hc-button'
 import * as soundHook from '../hooks/use-sound'
 
-jest.mock('../hooks/use-sound')
-
 describe('HCButton sound', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    cleanup()
+  })
+
   it('plays sound on click when enabled', () => {
     const play = jest.fn()
-    ;(soundHook.useSound as jest.Mock).mockReturnValue(play)
+    jest.spyOn(soundHook, 'useSound').mockReturnValue(play)
     render(<HCButton>Press</HCButton>)
     fireEvent.click(screen.getByRole('button'))
     expect(play).toHaveBeenCalled()
@@ -15,9 +18,43 @@ describe('HCButton sound', () => {
 
   it('does not play sound when sound prop is false', () => {
     const play = jest.fn()
-    ;(soundHook.useSound as jest.Mock).mockReturnValue(play)
+    jest.spyOn(soundHook, 'useSound').mockReturnValue(play)
     render(<HCButton sound={false}>Press</HCButton>)
     fireEvent.click(screen.getByRole('button'))
     expect(play).not.toHaveBeenCalled()
+  })
+
+  it('closes AudioContext on unmount', () => {
+    const close = jest.fn()
+    class MockAudioContext {
+      currentTime = 0
+      destination = {}
+      resume = jest.fn()
+      close = close
+      createOscillator() {
+        return {
+          type: 'sine',
+          frequency: { value: 0 },
+          connect: jest.fn(),
+          start: jest.fn(),
+          stop: jest.fn(),
+          disconnect: jest.fn(),
+          onended: null as any
+        }
+      }
+      createGain() {
+        return {
+          connect: jest.fn(),
+          disconnect: jest.fn(),
+          gain: { exponentialRampToValueAtTime: jest.fn() }
+        }
+      }
+    }
+    ;(global as any).AudioContext = MockAudioContext
+
+    render(<HCButton>Press</HCButton>)
+    fireEvent.click(screen.getByRole('button'))
+    cleanup()
+    expect(close).toHaveBeenCalled()
   })
 })

--- a/app/hooks/use-sound.ts
+++ b/app/hooks/use-sound.ts
@@ -1,8 +1,16 @@
 'use client'
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useEffect } from 'react'
 
 export function useSound(enabled: boolean = true) {
   const ctxRef = useRef<AudioContext | null>(null)
+
+  useEffect(() => {
+    return () => {
+      ctxRef.current?.close().catch(() => {})
+      ctxRef.current = null
+    }
+  }, [])
+
   return useCallback(() => {
     if (!enabled || typeof window === 'undefined') return
     const ctx = ctxRef.current ?? new AudioContext()
@@ -20,8 +28,8 @@ export function useSound(enabled: boolean = true) {
     gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2)
     osc.stop(now + 0.2)
     osc.onended = () => {
-      ctx.close().catch(() => {})
-      ctxRef.current = null
+      osc.disconnect()
+      gain.disconnect()
     }
   }, [enabled])
 }


### PR DESCRIPTION
## Summary
- keep a persistent `AudioContext` in `useSound`
- update button sound tests for persistent audio context
- document browser `AudioContext` limitations

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684cb78d700c832a97c9eba9da50fe85