### PR TITLE
Improve API route error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ yarn lint         # Run ESLint
 - **Introduce error boundaries** ✅ Application wrapped with a reusable error boundary component.
 - **Audit dependencies** ✅ Removed unused packages like charting and map libraries.
 - **Persist progress server-side** ✅ Progress now saved to a Prisma `Progress` table via an API route.
+- **Improved API error handling** ✅ Endpoints return `{ error: 'Internal server error' }` with a 500 status when database actions fail.
 
 ---
 

--- a/app/__tests__/api-routes.test.ts
+++ b/app/__tests__/api-routes.test.ts
@@ -1,0 +1,53 @@
+import { POST as progressPost, GET as progressGet } from '../app/api/progress/route'
+import { POST as quizPost, GET as quizGet } from '../app/api/quiz/route'
+import { prisma } from '../lib/db'
+import type { NextRequest } from 'next/server'
+
+jest.mock('../lib/db', () => ({
+  prisma: {
+    progress: { upsert: jest.fn(), findUnique: jest.fn() },
+    quizResult: { create: jest.fn(), findMany: jest.fn() }
+  }
+}))
+
+describe('API error handling', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('returns 500 when progress POST fails', async () => {
+    ;(prisma.progress.upsert as jest.Mock).mockRejectedValue(new Error('fail'))
+    const req = { json: jest.fn().mockResolvedValue({ sessionId: '1', state: {} }) } as unknown as NextRequest
+    const res = await progressPost(req)
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'Internal server error' })
+  })
+
+  it('returns 500 when progress GET fails', async () => {
+    ;(prisma.progress.findUnique as jest.Mock).mockRejectedValue(new Error('fail'))
+    const req = { nextUrl: { searchParams: new URLSearchParams('sessionId=1') } } as unknown as NextRequest
+    const res = await progressGet(req)
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'Internal server error' })
+  })
+
+  it('returns 500 when quiz POST fails', async () => {
+    ;(prisma.quizResult.create as jest.Mock).mockRejectedValue(new Error('fail'))
+    const req = { json: jest.fn().mockResolvedValue({ sessionId: '1', result: {}, score: 0 }) } as unknown as NextRequest
+    const res = await quizPost(req)
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'Internal server error' })
+  })
+
+  it('returns 500 when quiz GET fails', async () => {
+    ;(prisma.quizResult.findMany as jest.Mock).mockRejectedValue(new Error('fail'))
+    const req = { nextUrl: { searchParams: new URLSearchParams('sessionId=1') } } as unknown as NextRequest
+    const res = await quizGet(req)
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json).toEqual({ error: 'Internal server error' })
+  })
+})

--- a/app/app/api/progress/route.ts
+++ b/app/app/api/progress/route.ts
@@ -2,20 +2,30 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 
 export async function POST(request: NextRequest) {
-  const body = await request.json()
-  const { sessionId, state } = body
-  if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 })
-  const progress = await prisma.progress.upsert({
-    where: { sessionId },
-    update: { data: state },
-    create: { sessionId, data: state }
-  })
-  return NextResponse.json(progress)
+  try {
+    const body = await request.json()
+    const { sessionId, state } = body
+    if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 })
+    const progress = await prisma.progress.upsert({
+      where: { sessionId },
+      update: { data: state },
+      create: { sessionId, data: state }
+    })
+    return NextResponse.json(progress)
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
 }
 
 export async function GET(request: NextRequest) {
-  const sessionId = request.nextUrl.searchParams.get('sessionId') ?? ''
-  if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 })
-  const progress = await prisma.progress.findUnique({ where: { sessionId } })
-  return NextResponse.json(progress)
+  try {
+    const sessionId = request.nextUrl.searchParams.get('sessionId') ?? ''
+    if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 })
+    const progress = await prisma.progress.findUnique({ where: { sessionId } })
+    return NextResponse.json(progress)
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
 }

--- a/app/app/api/quiz/route.ts
+++ b/app/app/api/quiz/route.ts
@@ -2,24 +2,40 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const { sessionId, result, score } = body;
-  if (!sessionId) {
-    return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+  try {
+    const body = await request.json();
+    const { sessionId, result, score } = body;
+    if (!sessionId) {
+      return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+    }
+    const saved = await prisma.quizResult.create({
+      data: { sessionId, result, score },
+    });
+    return NextResponse.json(saved);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
   }
-  const saved = await prisma.quizResult.create({
-    data: { sessionId, result, score },
-  });
-  return NextResponse.json(saved);
 }
 
 export async function GET(request: NextRequest) {
-  const sessionId = request.nextUrl.searchParams.get('sessionId') ?? '';
-  if (!sessionId) {
-    return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+  try {
+    const sessionId = request.nextUrl.searchParams.get('sessionId') ?? '';
+    if (!sessionId) {
+      return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+    }
+    const result = await prisma.quizResult.findMany({
+      where: { sessionId },
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
   }
-  const result = await prisma.quizResult.findMany({
-    where: { sessionId },
-  });
-  return NextResponse.json(result);
 }


### PR DESCRIPTION
## Summary
- add try/catch error handling to progress and quiz API routes
- test new 500 error responses when database calls fail
- document error responses in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb7a8ca78832a8f17a5c7cab2420a