### PR TITLE
Improve progress sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ This project recreates the iconic HyperCard experience from 1987, complete with 
 3. **Progress Persistence**: Implemented localStorage for user progress tracking
 4. **Cross-browser Testing**: Ensured compatibility across modern browsers
 5. **Documentation**: Comprehensive README and code documentation
-6. **Debounced Server Updates**: Progress is now sent to the server in batches,
-   reducing network requests while local storage updates immediately
+6. **Conservative Server Sync**: Progress now syncs to the server only after a
+   card is completed (or 5s of inactivity). Failed syncs retry automatically and
+   surface an on-screen toast message.
 
 ## ✨ Current MVP Features
 
@@ -63,7 +64,8 @@ This project recreates the iconic HyperCard experience from 1987, complete with 
 ### Technical Features
 - **SPA Routing**: Direct URL access to specific cards (`/card/1`, `/card/2`, etc.)
 - **State Persistence**: localStorage integration for session continuity
-- **Debounced Server Sync**: Progress updates are batched before hitting the API
+- **Conservative Server Sync**: Progress updates save to the server after card
+  completion or a short delay, with retry and toast feedback on failure
 - **Keyboard Shortcuts**: Arrow keys (←/→) for navigation, Home key for card 1
 - **TypeScript Integration**: Full type safety throughout the application
 - **Component Architecture**: Reusable HyperCard-style components

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -2,6 +2,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { ThemeProvider } from '../components/theme-provider'
+import { Toaster } from '../components/ui/toaster'
 
 export const metadata: Metadata = {
   title: 'HyperCard AI Primer',
@@ -18,6 +19,7 @@ export default function RootLayout({
       <body className="suppress-hydration-warning">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/app/lib/hypercard-context.tsx
+++ b/app/lib/hypercard-context.tsx
@@ -1,9 +1,16 @@
 
 'use client';
 
-import React, { createContext, useContext, useReducer, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useReducer,
+  useEffect,
+  useState,
+} from 'react';
 import { HyperCardState, NavigationAction } from './types';
 import { TOTAL_CARDS } from './constants';
+import { toast } from '../components/ui/use-toast';
 
 const initialState: HyperCardState = {
   currentCard: 1,
@@ -130,25 +137,51 @@ export function HyperCardProvider({ children }: { children: React.ReactNode }) {
     return '';
   });
 
-  // Save to localStorage immediately and debounce server updates
+  // Save to localStorage immediately and batch server updates
   const latestStateRef = React.useRef(state);
   const saveTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
+  // keep the latest state in local storage on every change
   useEffect(() => {
     latestStateRef.current = state;
     localStorage.setItem('hypercard-ai-primer-state', JSON.stringify(state));
+  }, [state]);
 
+  // helper to persist progress to the server with basic retries
+  const persistProgress = React.useCallback(
+    async (attempt = 1) => {
+      try {
+        const res = await fetch('/api/progress', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId, state: latestStateRef.current }),
+        });
+        if (!res.ok) throw new Error(`status ${res.status}`);
+      } catch (e) {
+        if (attempt < 3) {
+          setTimeout(() => persistProgress(attempt + 1), attempt * 1000);
+        } else if (typeof window !== 'undefined') {
+          toast({
+            title: 'Failed to sync progress',
+            description: 'We\'ll keep trying in the background.',
+            variant: 'destructive',
+          });
+        }
+      }
+    },
+    [sessionId]
+  );
+
+  // debounce server updates when major progress milestones occur
+  useEffect(() => {
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
     }
-    saveTimeoutRef.current = setTimeout(() => {
-      fetch('/api/progress', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId, state: latestStateRef.current })
-      }).catch((e) => console.warn('Failed to save progress', e));
-    }, 1000);
-  }, [state, sessionId]);
+    saveTimeoutRef.current = setTimeout(persistProgress, 5000);
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    };
+  }, [state.currentCard, state.userProgress.completedSections, state.userProgress.quizScore, persistProgress]);
 
 
   return (


### PR DESCRIPTION
## Summary
- batch progress saves with a longer debounce
- retry progress sync on failure and show a toast
- expose the toast provider in the app layout
- document new sync behaviour

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684cb76d04d0832aa53c208f6f2a28e8